### PR TITLE
♻️ [Recycle] 홈탭 경험 가이드 라인 패딩으로 조절되도록 수정

### DIFF
--- a/FeelFarm/FeelFarm/Common/Common/Components/Home/Top/ExperienceGuide.swift
+++ b/FeelFarm/FeelFarm/Common/Common/Components/Home/Top/ExperienceGuide.swift
@@ -46,25 +46,25 @@ struct ExperienceGuide: View {
     }
     
     private var existenceGuide: some View {
-        ZStack {
-            Image(.versesBorder)
-                .resizable()
-                .frame(maxWidth: .infinity, maxHeight: 150)
-                .padding(20)
-                .background {
+        Text(text.split(separator: "").joined(separator: "\u{200B}"))
+            .font(.T16medium)
+            .foregroundStyle(Color.gray07)
+            .lineLimit(nil)
+            .lineSpacing(2.5)
+            .multilineTextAlignment(.leading)
+            .padding(.vertical, 40)
+            .padding(.horizontal, 30)
+            .background(content: {
+                ZStack(content: {
                     RoundedRectangle(cornerRadius: 8)
                         .fill(Color.white)
                         .shadow03()
-                }
-            
-                Text(text)
-                    .frame(width: 284, height: 74)
-                    .font(.T13medium)
-                    .foregroundStyle(Color.gray07)
-                    .lineLimit(nil)
-                    .lineSpacing(2.5)
-                    .multilineTextAlignment(.leading)
-        }
+                    
+                    Image(.versesBorder)
+                        .resizable()
+                        .padding(10)
+                })
+            })
     }
 }
 

--- a/FeelFarm/FeelFarm/Common/Common/Components/My/MyExperienceCard.swift
+++ b/FeelFarm/FeelFarm/Common/Common/Components/My/MyExperienceCard.swift
@@ -28,7 +28,7 @@ struct MyExperienceCard: View {
             Spacer()
             
             Text(emotionReponse.content)
-                .font(.T12medium)
+                .font(.T14medium)
                 .foregroundStyle(Color.black)
                 .lineLimit(nil)
                 .lineSpacing(2.5)

--- a/FeelFarm/FeelFarm/Module/Home/HomeView.swift
+++ b/FeelFarm/FeelFarm/Module/Home/HomeView.swift
@@ -14,7 +14,6 @@ struct HomeView: View {
     
     var body: some View {
         ScrollView(.vertical, content: {
-                
                 VStack(spacing: 40) {
                     userProfile
                     topContents

--- a/FeelFarm/FeelFarm/Module/Home/HomeViewModel.swift
+++ b/FeelFarm/FeelFarm/Module/Home/HomeViewModel.swift
@@ -16,7 +16,7 @@ class HomeViewModel {
     var isEmotionPickerViewAnimation: Bool = false
     var isEmotionPickerPresented: Bool = false
     
-    var emotionReponse: EmotionResponse? = .init(id: "0", emotion: .happy, content: "오늘 SwiftUI의 수정자를 공부했어요!", feedback: "으아아", date: .now, field: .design, sharePostId: "11")
+    var emotionReponse: EmotionResponse? = .init(id: "0", emotion: .happy, content: "오늘 SwiftUI의 수정자를 공부했어요!오늘 SwiftUI의 수정자를 공부했어요!오늘 SwiftUI의 수정자를 공부했어요!으아아앙으아아아아ㅡ앙아ㅏ아으아아아아ㅡ아아아으아아아으아아앙", feedback: "으아아", date: .now, field: .design, sharePostId: "11")
     var sharedEmotion: [SharedEmotion]? = [
         .init(id: "1", content: "우선순위가 계속 바뀌는 바람에..", emotion: .sad, feedback: "정말 잘했어요!", field: .design, nickname: "제옹", uid: "123", date: .now),
         .init(id: "2", content: "피그마 사용법을 공부했는데 참고..", emotion: .touched, feedback: "정말 잘했어요!", field: .design, nickname: "제옹", uid: "123", date: .now),

--- a/FeelFarm/FeelFarm/Module/Share/ShareView.swift
+++ b/FeelFarm/FeelFarm/Module/Share/ShareView.swift
@@ -13,36 +13,26 @@ struct ShareView: View {
     @EnvironmentObject var container: DIContainer
     
     var body: some View {
-        VStack(alignment: .leading, spacing: 33) {
-            TopStatus(text: "러너 경험 공유", action: nil)
-            
-            Group {
-            CustomSegment<FieldType>(selectedSegment: $viewModel.selectedSegment)
-                
-                if !viewModel.sharedData.isEmpty {
-                    ScrollView(.vertical, content: {
-                        LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 1), spacing: 10) {
-                            ForEach(viewModel.sharedData.indices, id: \.self) { index in
-                                let shareData = viewModel.sharedData[index]
-                                
-                                VStack(spacing: 10) {
-                                    LearnerExperienceCard(shareData: shareData)
-                                    
-                                    if index < viewModel.sharedData.count - 1 {
-                                        Divider()
-                                            .foregroundStyle(Color.gray03)
-                                            .frame(maxWidth: .infinity,  maxHeight: 1)
-                                    }
-                                }
-                            }
-                        }
-                    })
-                    .contentMargins(.bottom, 20)
-                } else {
-                    noExperienceData
-                }
-            }
+        NavigationStack {
+            ScrollView(.vertical, content: {
+                VStack(alignment: .leading, spacing: 33, content: {
+                    CustomSegment<FieldType>(selectedSegment: $viewModel.selectedSegment)
+                    
+                    if !viewModel.sharedData.isEmpty {
+                        contents
+                    } else {
+                        noExperienceData
+                    }
+                })
+            })
             .safeAreaPadding(.horizontal, 16)
+            .contentMargins(.top, 20)
+            .background(Color.white)
+            .navigationTitle(
+                Text("Runner Stories")
+                    .font(.T20Semibold)
+            )
+            .navigationBarTitleDisplayMode(.automatic)
         }
     }
     
@@ -65,8 +55,25 @@ struct ShareView: View {
                 .frame(maxWidth: .infinity)
                 .padding(.top, 16)
         }
-        
         Spacer()
+    }
+    
+    private var contents: some View {
+        LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 1), spacing: 10) {
+            ForEach(viewModel.sharedData.indices, id: \.self) { index in
+                let shareData = viewModel.sharedData[index]
+                
+                VStack(spacing: 10) {
+                    LearnerExperienceCard(shareData: shareData)
+                    
+                    if index < viewModel.sharedData.count - 1 {
+                        Divider()
+                            .foregroundStyle(Color.gray03)
+                            .frame(maxWidth: .infinity,  maxHeight: 1)
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/FeelFarm/FeelFarm/Module/Share/ShareViewModel.swift
+++ b/FeelFarm/FeelFarm/Module/Share/ShareViewModel.swift
@@ -11,6 +11,12 @@ import Foundation
 class ShareViewModel {
     var selectedSegment: FieldType = .domain
     var sharedData: [SharedEmotion] = [
-        .init(id: "123", content: "개발 너무 어려워서 못하겠어용 흥행행 잉잉잉 으아아아아아아아아미미ㅣ잉이미ㅣ이이", emotion: .happy, feedback: "으아아", field: .domain, nickname: "쿨냥", uid: "~11", date: Date())
+        .init(id: "123", content: "개발 너무 어려워서 못하겠어용 흥행행 잉잉잉 으아아아아아아아아미미ㅣ잉이미ㅣ이이", emotion: .happy, feedback: "으아아", field: .domain, nickname: "쿨냥", uid: "~11", date: Date()),
+        .init(id: "1232", content: "개발 너무 어려워서 못하겠어용 흥행행 잉잉잉 으아아아아아아아아미미ㅣ잉이미ㅣ이이", emotion: .happy, feedback: "으아아", field: .domain, nickname: "쿨냥", uid: "~11", date: Date()),
+        .init(id: "1233", content: "개발 너무 어려워서 못하겠어용 흥행행 잉잉잉 으아아아아아아아아미미ㅣ잉이미ㅣ이이", emotion: .happy, feedback: "으아아", field: .domain, nickname: "쿨냥", uid: "~11", date: Date()),
+        .init(id: "12113", content: "개발 너무 어려워서 못하겠어용 흥행행 잉잉잉 으아아아아아아아아미미ㅣ잉이미ㅣ이이", emotion: .happy, feedback: "으아아", field: .domain, nickname: "쿨냥", uid: "~11", date: Date()),
+        .init(id: "1233", content: "개발 너무 어려워서 못하겠어용 흥행행 잉잉잉 으아아아아아아아아미미ㅣ잉이미ㅣ이이", emotion: .happy, feedback: "으아아", field: .domain, nickname: "쿨냥", uid: "~11", date: Date()),
+        .init(id: "11223", content: "개발 너무 어려워서 못하겠어용 흥행행 잉잉잉 으아아아아아아아아미미ㅣ잉이미ㅣ이이", emotion: .happy, feedback: "으아아", field: .domain, nickname: "쿨냥", uid: "~11", date: Date()),
+        .init(id: "123412423", content: "개발 너무 어려워서 못하겠어용 흥행행 잉잉잉 으아아아아아아아아미미ㅣ잉이미ㅣ이이", emotion: .happy, feedback: "으아아", field: .domain, nickname: "쿨냥", uid: "~11", date: Date())
     ]
 }

--- a/FeelFarm/FeelFarm/Module/TabView/FeelFarmTabView.swift
+++ b/FeelFarm/FeelFarm/Module/TabView/FeelFarmTabView.swift
@@ -16,8 +16,8 @@ struct FeelFarmTabView: View {
         TabView(selection: $tabcase, content: {
             ForEach(TabCase.allCases, id: \.rawValue) { tab in
                 Tab(value: tab, content: {
-                    tabView(for: tab)
-                        .tag(tab)
+                        tabView(for: tab)
+                            .tag(tab)
                 }, label: {
                     VStack(spacing: 5, content: {
                         tab.icon


### PR DESCRIPTION
글자 영역 다 보이도록 패딩으로 자동 조절처리

## ✨ PR 유형

어떤 변경 사항이 있나요??

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 사용자 UI 디자인 변경 및 추가
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## 🛠️ 작업내용
[ 작업한 내용을 작성해주세요 ( UI 구현이라면 사진도 같이 올려주시면 좋아요! ) ]
1. 홈탭 가이드 라인 수정
2. 폰트 수정
## 📋 추후 진행 상황
[ 다음에 진행할 작업에 대해 작성해주세요!! ]</br>
[ 현재 커밋 후 풀리퀘 다음으로 작업 내용을 적어주면 됩니다! ]
1. 상세화면 구현
2. 경험 생성 화면 구현
## 📌 리뷰 포인트
[ 어떤 부분을 잘 체크해야하는지 작성해주세요 ]



## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)
